### PR TITLE
Fixed multiple quote's flashing issue

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,7 +24,7 @@ function Header() {
     useEffect(() => {
          api();
          
-    })
+    }, [])
     
 
     return (


### PR DESCRIPTION
Update useEffect to only run on load. 

Because you updated state at the end of every "api()" call, the useEffect would be called again. Causing an infinite loop hitting the api as many times as possible in the 5 second timeframe. 

Having the useEffect run only once on load solves this issue.